### PR TITLE
Incrementado CURL Timeout

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -126,7 +126,7 @@ class ApiClient
             ),
             CURLOPT_URL => $this->buildUrl($uri),
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_TIMEOUT => 10,
+            CURLOPT_TIMEOUT => 30,
             CURLOPT_CUSTOMREQUEST => $method,
             CURLOPT_SSL_VERIFYPEER => self::isSslCertsVerificationEnabled()
         );


### PR DESCRIPTION
Algumas requisições podem levar mais de 10 segundos para retornar do mundipagg, ao ser ultrapassado esse limite, retorna um 'Error processing Request', mas a compra pode ter sido ou não aprovada no Mundipagg.