### PR TITLE
Mundipagg/feature/notification url boleto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,5 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
-  - nightly
 
 after_script: ./vendor/bin/coveralls -v

--- a/examples/createBoleto.php
+++ b/examples/createBoleto.php
@@ -26,7 +26,8 @@ try
     ->getOptions()
     ->setCurrencyIso(\Gateway\One\DataContract\Enum\CurrencyIsoEnum::BRL)
     ->setDaysToAddInBoletoExpirationDate(5)
-    ->setNotificationUrl("http://myurl.com");
+    ->setNotificationUrl("http://myurl.com")
+    ->setIsNotificationEnabled(true);
 
     // Endereço de cobrança do comprador no do boleto
     $boletoTransaction->getBillingAddress()

--- a/examples/createBoleto.php
+++ b/examples/createBoleto.php
@@ -25,7 +25,8 @@ try
     ->setTransactionReference(uniqid())
     ->getOptions()
     ->setCurrencyIso(\Gateway\One\DataContract\Enum\CurrencyIsoEnum::BRL)
-    ->setDaysToAddInBoletoExpirationDate(5);
+    ->setDaysToAddInBoletoExpirationDate(5)
+    ->setNotificationUrl("http://myurl.com");
 
     // Endereço de cobrança do comprador no do boleto
     $boletoTransaction->getBillingAddress()

--- a/examples/createCreditCardTransaction.php
+++ b/examples/createCreditCardTransaction.php
@@ -48,7 +48,8 @@ try
     ->setInterestRate(0)
     ->setPaymentMethodCode(\Gateway\One\DataContract\Enum\PaymentMethodEnum::SIMULATOR)
     ->setSoftDescriptorText("TESTE")
-    ->setNotificationUrl("http://myurl.com");
+    ->setNotificationUrl("http://myurl.com")
+    ->setIsNotificationEnabled(true);
 
     // Dados do comprador
     $request->getBuyer()

--- a/lib/One/DataContract/Request/CreateSaleRequestData/BoletoTransactionOptions.php
+++ b/lib/One/DataContract/Request/CreateSaleRequestData/BoletoTransactionOptions.php
@@ -26,6 +26,11 @@ class BoletoTransactionOptions extends BaseObject
     protected $notificationUrl;
 
     /**
+     * @var boolean 
+     */
+    protected $IsNotificationEnabled;
+
+    /**
      * @return string
      */
     public function getCurrencyIso()
@@ -73,4 +78,15 @@ class BoletoTransactionOptions extends BaseObject
 
        return $this;
    }
+
+   /**
+     * @param boolean $IsNotificationEnabled
+     * @return $this
+     */
+    public function setIsNotificationEnabled($IsNotificationEnabled)
+    {
+        $this->IsNotificationEnabled = $IsNotificationEnabled;
+
+        return $this;
+    }
 }

--- a/lib/One/DataContract/Request/CreateSaleRequestData/BoletoTransactionOptions.php
+++ b/lib/One/DataContract/Request/CreateSaleRequestData/BoletoTransactionOptions.php
@@ -20,6 +20,11 @@ class BoletoTransactionOptions extends BaseObject
      */
     protected $DaysToAddInBoletoExpirationDate;
 
+     /**
+     * @var string Url de notificação
+     */
+    protected $notificationUrl;
+
     /**
      * @return string
      */
@@ -57,4 +62,15 @@ class BoletoTransactionOptions extends BaseObject
 
         return $this;
     }
+
+    /**
+    * @param string $notificationUrl
+    * @return $this
+    */
+   public function setNotificationUrl($notificationUrl)
+   {
+       $this->NotificationUrl = $notificationUrl;
+
+       return $this;
+   }
 }

--- a/lib/One/DataContract/Request/CreateSaleRequestData/CreditCardTransactionOptions.php
+++ b/lib/One/DataContract/Request/CreateSaleRequestData/CreditCardTransactionOptions.php
@@ -180,7 +180,7 @@ class CreditCardTransactionOptions extends BaseObject
     }
 
     /**
-     * @param bool $IsNotificationEnabled
+     * @param boolean $IsNotificationEnabled
      * @return $this
      */
     public function setIsNotificationEnabled($IsNotificationEnabled)

--- a/lib/One/DataContract/Request/CreateSaleRequestData/CreditCardTransactionOptions.php
+++ b/lib/One/DataContract/Request/CreateSaleRequestData/CreditCardTransactionOptions.php
@@ -49,6 +49,12 @@ class CreditCardTransactionOptions extends BaseObject
     protected $notificationUrl;
 
     /**
+     * @var boolean 
+     */
+    protected $IsNotificationEnabled;
+
+
+    /**
      * @return string
      */
     public function getCurrencyIso()
@@ -169,6 +175,17 @@ class CreditCardTransactionOptions extends BaseObject
     public function setNotificationUrl($notificationUrl)
     {
         $this->NotificationUrl = $notificationUrl;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $IsNotificationEnabled
+     * @return $this
+     */
+    public function setIsNotificationEnabled($IsNotificationEnabled)
+    {
+        $this->IsNotificationEnabled = $IsNotificationEnabled;
 
         return $this;
     }


### PR DESCRIPTION
O que faz?
Implementa a opção de enviar a url de forma explícita para o post de notificação de boleto.
Implementa a opção de receber o post de notificação ou não para uma determinada transação.

Por que?
Porque essa feature foi feita na api e não estava atualizada na sdk.

Como?
Inserindo os campos NotificationUrl e IsNotificationEnabled no contrato e no teste.

NotificationUrl - url de notificação
IsNotificationEnabled - Informa se a transação deve receber um post de notificação ou não.